### PR TITLE
ci: advance dependency revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "attribute-dsl"
 version = "0.2.0"
-source = "git+https://github.com/stayhydated/attribute-dsl?rev=bb69a6ee0a6772895d180113515fbb6cb46acc9d#bb69a6ee0a6772895d180113515fbb6cb46acc9d"
+source = "git+https://github.com/stayhydated/attribute-dsl?rev=8b04f86977802d5e8039ca0d14c81e8440771f08#8b04f86977802d5e8039ca0d14c81e8440771f08"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "component-shape"
 version = "0.2.0"
-source = "git+https://github.com/stayhydated/component-shape?rev=09ebec5af9fc3522e96b272d79036501b9116d60#09ebec5af9fc3522e96b272d79036501b9116d60"
+source = "git+https://github.com/stayhydated/component-shape?rev=acd8f941ae78f69ffc08408bf484ee94e51e7eb4#acd8f941ae78f69ffc08408bf484ee94e51e7eb4"
 dependencies = [
  "derive_more",
  "heck 0.5.0",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "component-shape-mcp"
 version = "0.2.0"
-source = "git+https://github.com/stayhydated/component-shape?rev=09ebec5af9fc3522e96b272d79036501b9116d60#09ebec5af9fc3522e96b272d79036501b9116d60"
+source = "git+https://github.com/stayhydated/component-shape?rev=acd8f941ae78f69ffc08408bf484ee94e51e7eb4#acd8f941ae78f69ffc08408bf484ee94e51e7eb4"
 dependencies = [
  "component-shape",
  "component-shape-mcp-macros",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "component-shape-mcp-macros"
 version = "0.2.0"
-source = "git+https://github.com/stayhydated/component-shape?rev=09ebec5af9fc3522e96b272d79036501b9116d60#09ebec5af9fc3522e96b272d79036501b9116d60"
+source = "git+https://github.com/stayhydated/component-shape?rev=acd8f941ae78f69ffc08408bf484ee94e51e7eb4#acd8f941ae78f69ffc08408bf484ee94e51e7eb4"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2765,7 +2765,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3018,13 +3018,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "es-fluent"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -3037,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-build"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-toml",
 ]
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "darling 0.24.0",
  "es-fluent-derive-core",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "bon",
  "darling 0.24.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-lang"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-lang-macro"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-toml",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-shared",
  "fluent-bundle",
@@ -3126,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-embedded"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-macros"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-shared",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-shared"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "anyhow",
  "camino",
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-toml"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "bon",
  "es-fluent-shared",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "frame-capture"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/frame-capture?rev=656510bb36873fff1a32dcea3510159108bf5ea8#656510bb36873fff1a32dcea3510159108bf5ea8"
+source = "git+https://github.com/stayhydated/frame-capture?rev=a9027c70f830aceaae3b4df44b7f044d286f9ce6#a9027c70f830aceaae3b4df44b7f044d286f9ce6"
 dependencies = [
  "bon",
  "derive_more",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "frame-capture-macros"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/frame-capture?rev=656510bb36873fff1a32dcea3510159108bf5ea8#656510bb36873fff1a32dcea3510159108bf5ea8"
+source = "git+https://github.com/stayhydated/frame-capture?rev=a9027c70f830aceaae3b4df44b7f044d286f9ce6#a9027c70f830aceaae3b4df44b7f044d286f9ce6"
 dependencies = [
  "darling 0.24.0",
  "frame-capture-toml",
@@ -3557,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "frame-capture-toml"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/frame-capture?rev=656510bb36873fff1a32dcea3510159108bf5ea8#656510bb36873fff1a32dcea3510159108bf5ea8"
+source = "git+https://github.com/stayhydated/frame-capture?rev=a9027c70f830aceaae3b4df44b7f044d286f9ce6#a9027c70f830aceaae3b4df44b7f044d286f9ce6"
 dependencies = [
  "serde",
  "thiserror 2.0.19",
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=b104b172c0e365d03a2e6c0d79fbcc78b171306f#b104b172c0e365d03a2e6c0d79fbcc78b171306f"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=71ae96cdf29d53b5434eb7aadd4036d3a25f9f70#71ae96cdf29d53b5434eb7aadd4036d3a25f9f70"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -5134,7 +5134,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5794,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "koruma"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "koruma-core 0.11.0",
  "koruma-derive",
@@ -5809,12 +5809,12 @@ checksum = "268f7d209f7793d0b6c0a15942a8bc82db1097f1a4d8a6a76855b9dc2d2314bd"
 [[package]]
 name = "koruma-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 
 [[package]]
 name = "koruma-derive"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "heck 0.5.0",
  "koruma-derive-core",
@@ -5827,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "koruma-derive-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "attribute-dsl",
  "heck 0.5.0",
@@ -6731,7 +6731,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6883,7 +6883,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8138,7 +8138,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8788,7 +8788,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10040,10 +10040,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11611,7 +11611,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -966,7 +966,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2049,6 +2049,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -3018,13 +3019,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "es-fluent"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -3037,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-build"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-toml",
 ]
@@ -3045,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "darling 0.24.0",
  "es-fluent-derive-core",
@@ -3058,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "bon",
  "darling 0.24.0",
@@ -3077,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-lang"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -3093,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-lang-macro"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-toml",
@@ -3107,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-shared",
  "fluent-bundle",
@@ -3126,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-embedded"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -3139,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-macros"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-shared",
@@ -3155,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-shared"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "anyhow",
  "camino",
@@ -3178,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-toml"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "bon",
  "es-fluent-shared",
@@ -4280,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=8d64313a33d3b5f08775b4846f9aca4655147831#8d64313a33d3b5f08775b4846f9aca4655147831"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=32e8e787a07b5af81df1a120a5e13afa885ec534#32e8e787a07b5af81df1a120a5e13afa885ec534"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -5134,7 +5135,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5794,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "koruma"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "koruma-core 0.11.0",
  "koruma-derive",
@@ -5809,12 +5810,12 @@ checksum = "268f7d209f7793d0b6c0a15942a8bc82db1097f1a4d8a6a76855b9dc2d2314bd"
 [[package]]
 name = "koruma-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 
 [[package]]
 name = "koruma-derive"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "heck 0.5.0",
  "koruma-derive-core",
@@ -5827,7 +5828,7 @@ dependencies = [
 [[package]]
 name = "koruma-derive-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "attribute-dsl",
  "heck 0.5.0",
@@ -8138,7 +8139,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8775,7 +8776,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8788,7 +8789,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8856,7 +8857,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10043,7 +10044,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11611,7 +11612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -966,7 +966,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2765,7 +2765,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3018,7 +3018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=71ae96cdf29d53b5434eb7aadd4036d3a25f9f70#71ae96cdf29d53b5434eb7aadd4036d3a25f9f70"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=8d64313a33d3b5f08775b4846f9aca4655147831#8d64313a33d3b5f08775b4846f9aca4655147831"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -5134,7 +5134,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6731,7 +6731,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8138,7 +8138,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8788,7 +8788,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10040,10 +10040,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11611,7 +11611,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,17 @@ component-shape-mcp = { git = "https://github.com/stayhydated/component-shape", 
 darling = "0.24"
 derive_more = "2.1"
 dioxus = { default-features = false, version = "0.7" }
-es-fluent = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
-es-fluent-build = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
-es-fluent-lang = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
-es-fluent-manager-core = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
-es-fluent-manager-embedded = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
+es-fluent = { git = "https://github.com/stayhydated/es-fluent", rev = "ec72a62d176770424b02f7cb194cb167a16aeb0e", version = "0.18.1" }
+es-fluent-build = { git = "https://github.com/stayhydated/es-fluent", rev = "ec72a62d176770424b02f7cb194cb167a16aeb0e", version = "0.18.1" }
+es-fluent-lang = { git = "https://github.com/stayhydated/es-fluent", rev = "ec72a62d176770424b02f7cb194cb167a16aeb0e", version = "0.18.1" }
+es-fluent-manager-core = { git = "https://github.com/stayhydated/es-fluent", rev = "ec72a62d176770424b02f7cb194cb167a16aeb0e", version = "0.18.1" }
+es-fluent-manager-embedded = { git = "https://github.com/stayhydated/es-fluent", rev = "ec72a62d176770424b02f7cb194cb167a16aeb0e", version = "0.18.1" }
 fluent-langneg = "=0.13.1"
 frame-capture = { git = "https://github.com/stayhydated/frame-capture", rev = "a9027c70f830aceaae3b4df44b7f044d286f9ce6", version = "0.1.0" }
 gpui = { branch = "linux-headless-renderer", git = "https://github.com/stayhydated/zed", version = "0.2.2" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }
-gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "8d64313a33d3b5f08775b4846f9aca4655147831", version = "0.1.0" }
+gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "32e8e787a07b5af81df1a120a5e13afa885ec534", version = "0.1.0" }
 gpui-storybook = { path = "crates/gpui-storybook", version = "0.5.0" }
 gpui-storybook-components = { path = "crates/gpui-storybook-components", version = "0.5.0" }
 gpui-storybook-core = { path = "crates/gpui-storybook-core", version = "0.5.0" }
@@ -61,7 +61,7 @@ image = { default-features = false, features = [ "png" ], version = "0.25" }
 insta = "1.48"
 inventory = "0.3"
 itertools = "0.15"
-koruma = { git = "https://github.com/stayhydated/koruma", rev = "efbac2d9bddeade53c61f85f5a5ddaa689a01970", version = "0.11.0" }
+koruma = { git = "https://github.com/stayhydated/koruma", rev = "081f2f33da7f8f288966e7ffa73d595aa7d2a510", version = "0.11.0" }
 libc = "0.2"
 prettyplease = "0.3"
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ frame-capture = { git = "https://github.com/stayhydated/frame-capture", rev = "a
 gpui = { branch = "linux-headless-renderer", git = "https://github.com/stayhydated/zed", version = "0.2.2" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }
-gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "71ae96cdf29d53b5434eb7aadd4036d3a25f9f70", version = "0.1.0" }
+gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "8d64313a33d3b5f08775b4846f9aca4655147831", version = "0.1.0" }
 gpui-storybook = { path = "crates/gpui-storybook", version = "0.5.0" }
 gpui-storybook-components = { path = "crates/gpui-storybook-components", version = "0.5.0" }
 gpui-storybook-core = { path = "crates/gpui-storybook-core", version = "0.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,21 +27,21 @@ version = "0.5.0"
 [workspace.dependencies]
 anyhow = "1.0"
 clap = "4.6"
-component-shape-mcp = { git = "https://github.com/stayhydated/component-shape", rev = "09ebec5af9fc3522e96b272d79036501b9116d60", version = "0.2.0" }
+component-shape-mcp = { git = "https://github.com/stayhydated/component-shape", rev = "acd8f941ae78f69ffc08408bf484ee94e51e7eb4", version = "0.2.0" }
 darling = "0.24"
 derive_more = "2.1"
 dioxus = { default-features = false, version = "0.7" }
-es-fluent = { git = "https://github.com/stayhydated/es-fluent", rev = "be9ccf8d9fc5e417e2605af3b648a6199cb39f8d", version = "0.18.1" }
-es-fluent-build = { git = "https://github.com/stayhydated/es-fluent", rev = "be9ccf8d9fc5e417e2605af3b648a6199cb39f8d", version = "0.18.1" }
-es-fluent-lang = { git = "https://github.com/stayhydated/es-fluent", rev = "be9ccf8d9fc5e417e2605af3b648a6199cb39f8d", version = "0.18.1" }
-es-fluent-manager-core = { git = "https://github.com/stayhydated/es-fluent", rev = "be9ccf8d9fc5e417e2605af3b648a6199cb39f8d", version = "0.18.1" }
-es-fluent-manager-embedded = { git = "https://github.com/stayhydated/es-fluent", rev = "be9ccf8d9fc5e417e2605af3b648a6199cb39f8d", version = "0.18.1" }
+es-fluent = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
+es-fluent-build = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
+es-fluent-lang = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
+es-fluent-manager-core = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
+es-fluent-manager-embedded = { git = "https://github.com/stayhydated/es-fluent", rev = "8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9", version = "0.18.1" }
 fluent-langneg = "=0.13.1"
-frame-capture = { git = "https://github.com/stayhydated/frame-capture", rev = "656510bb36873fff1a32dcea3510159108bf5ea8", version = "0.1.0" }
+frame-capture = { git = "https://github.com/stayhydated/frame-capture", rev = "a9027c70f830aceaae3b4df44b7f044d286f9ce6", version = "0.1.0" }
 gpui = { branch = "linux-headless-renderer", git = "https://github.com/stayhydated/zed", version = "0.2.2" }
 gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component" }
-gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "b104b172c0e365d03a2e6c0d79fbcc78b171306f", version = "0.1.0" }
+gpui-es-fluent = { git = "https://github.com/stayhydated/gpui-es-fluent", rev = "71ae96cdf29d53b5434eb7aadd4036d3a25f9f70", version = "0.1.0" }
 gpui-storybook = { path = "crates/gpui-storybook", version = "0.5.0" }
 gpui-storybook-components = { path = "crates/gpui-storybook-components", version = "0.5.0" }
 gpui-storybook-core = { path = "crates/gpui-storybook-core", version = "0.5.0" }
@@ -61,7 +61,7 @@ image = { default-features = false, features = [ "png" ], version = "0.25" }
 insta = "1.48"
 inventory = "0.3"
 itertools = "0.15"
-koruma = { git = "https://github.com/stayhydated/koruma", rev = "0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8", version = "0.11.0" }
+koruma = { git = "https://github.com/stayhydated/koruma", rev = "efbac2d9bddeade53c61f85f5a5ddaa689a01970", version = "0.11.0" }
 libc = "0.2"
 prettyplease = "0.3"
 proc-macro2 = "1.0"

--- a/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
+++ b/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1297,7 +1297,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1467,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=71ae96cdf29d53b5434eb7aadd4036d3a25f9f70#71ae96cdf29d53b5434eb7aadd4036d3a25f9f70"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=8d64313a33d3b5f08775b4846f9aca4655147831#8d64313a33d3b5f08775b4846f9aca4655147831"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -2906,7 +2906,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4685,7 +4685,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5171,7 +5171,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6988,7 +6988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7088,19 +7088,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -7241,15 +7228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7275,15 +7253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
+++ b/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "attribute-dsl"
 version = "0.2.0"
-source = "git+https://github.com/stayhydated/attribute-dsl?rev=bb69a6ee0a6772895d180113515fbb6cb46acc9d#bb69a6ee0a6772895d180113515fbb6cb46acc9d"
+source = "git+https://github.com/stayhydated/attribute-dsl?rev=8b04f86977802d5e8039ca0d14c81e8440771f08#8b04f86977802d5e8039ca0d14c81e8440771f08"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1297,7 +1297,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1467,13 +1467,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "es-fluent"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-build"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-toml",
 ]
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "darling 0.24.0",
  "es-fluent-derive-core",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "bon",
  "darling 0.24.0",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-shared",
  "fluent-bundle",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-embedded"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-macros"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-shared",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-shared"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "anyhow",
  "camino",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-toml"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=be9ccf8d9fc5e417e2605af3b648a6199cb39f8d#be9ccf8d9fc5e417e2605af3b648a6199cb39f8d"
+source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
 dependencies = [
  "bon",
  "es-fluent-shared",
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=b104b172c0e365d03a2e6c0d79fbcc78b171306f#b104b172c0e365d03a2e6c0d79fbcc78b171306f"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=71ae96cdf29d53b5434eb7aadd4036d3a25f9f70#71ae96cdf29d53b5434eb7aadd4036d3a25f9f70"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "koruma"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "koruma-core",
  "koruma-derive",
@@ -3291,12 +3291,12 @@ dependencies = [
 [[package]]
 name = "koruma-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 
 [[package]]
 name = "koruma-derive"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "heck 0.5.0",
  "koruma-derive-core",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "koruma-derive-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8#0e92fde0b37f7caff376b8d95ed7fae1b18d3ed8"
+source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
 dependencies = [
  "attribute-dsl",
  "heck 0.5.0",
@@ -3840,7 +3840,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4685,7 +4685,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5171,7 +5171,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6988,7 +6988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
+++ b/crates/gpui-storybook/tests/fixtures/duplicate-story-key/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1467,13 +1467,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "es-fluent"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-build"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-toml",
 ]
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "darling 0.24.0",
  "es-fluent-derive-core",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-derive-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "bon",
  "darling 0.24.0",
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-core"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-shared",
  "fluent-bundle",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-embedded"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-manager-macros"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "es-fluent-derive-core",
  "es-fluent-shared",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-shared"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "anyhow",
  "camino",
@@ -1597,7 +1597,7 @@ dependencies = [
 [[package]]
 name = "es-fluent-toml"
 version = "0.18.1"
-source = "git+https://github.com/stayhydated/es-fluent?rev=8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9#8ff586b958c3e17bfc530b2ddf7b7a5c87b716b9"
+source = "git+https://github.com/stayhydated/es-fluent?rev=ec72a62d176770424b02f7cb194cb167a16aeb0e#ec72a62d176770424b02f7cb194cb167a16aeb0e"
 dependencies = [
  "bon",
  "es-fluent-shared",
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "gpui-es-fluent"
 version = "0.1.0"
-source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=8d64313a33d3b5f08775b4846f9aca4655147831#8d64313a33d3b5f08775b4846f9aca4655147831"
+source = "git+https://github.com/stayhydated/gpui-es-fluent?rev=32e8e787a07b5af81df1a120a5e13afa885ec534#32e8e787a07b5af81df1a120a5e13afa885ec534"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -2906,7 +2906,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "koruma"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "koruma-core",
  "koruma-derive",
@@ -3291,12 +3291,12 @@ dependencies = [
 [[package]]
 name = "koruma-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 
 [[package]]
 name = "koruma-derive"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "heck 0.5.0",
  "koruma-derive-core",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "koruma-derive-core"
 version = "0.11.0"
-source = "git+https://github.com/stayhydated/koruma?rev=efbac2d9bddeade53c61f85f5a5ddaa689a01970#efbac2d9bddeade53c61f85f5a5ddaa689a01970"
+source = "git+https://github.com/stayhydated/koruma?rev=081f2f33da7f8f288966e7ffa73d595aa7d2a510#081f2f33da7f8f288966e7ffa73d595aa7d2a510"
 dependencies = [
  "attribute-dsl",
  "heck 0.5.0",
@@ -4685,7 +4685,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5158,7 +5158,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5171,7 +5171,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6988,7 +6988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Advances every direct and fixture lockfile pin for component-shape, es-fluent, frame-capture, gpui-es-fluent, and koruma to their CI-fix revisions. The merged master branch already contains the Windows sccache workaround. Validated both root and fixture manifests with locked cargo metadata.